### PR TITLE
Bufix: not allowed to update a role libelle

### DIFF
--- a/src/Distilleries/Expendable/Forms/Role/RoleForm.php
+++ b/src/Distilleries/Expendable/Forms/Role/RoleForm.php
@@ -11,6 +11,12 @@ class RoleForm extends FormValidator {
         'overide_permission' => 'integer'
     ];
 
+    public static $rules_update = [
+        'libelle'            => 'required',
+        'initials'           => 'required',
+        'overide_permission' => 'integer'
+    ];
+
     public function buildForm()
     {
         $this

--- a/src/Distilleries/Expendable/Forms/Role/RoleForm.php
+++ b/src/Distilleries/Expendable/Forms/Role/RoleForm.php
@@ -13,7 +13,7 @@ class RoleForm extends FormValidator {
 
     public static $rules_update = [
         'libelle'            => 'required',
-        'initials'           => 'required',
+        'initials'           => 'required|unique:roles,initials',
         'overide_permission' => 'integer'
     ];
 


### PR DESCRIPTION
The validations rule 'unique:roles' prevented the user from updating the role without changing the initials.